### PR TITLE
idf proposed fixes. Tested also in Arduino IDE

### DIFF
--- a/src/FastEPD.inl
+++ b/src/FastEPD.inl
@@ -17,7 +17,7 @@
 #include "FastEPD.h"
 #include <esp_lcd_panel_io.h>
 #include <esp_lcd_panel_ops.h>
-
+#include <esp_log.h>
 #if PSRAM != enabled && !defined(CONFIG_ESP32_SPIRAM_SUPPORT) && !defined(CONFIG_ESP32S3_SPIRAM_SUPPORT)
 #error "Please enable PSRAM support"
 #endif
@@ -939,6 +939,7 @@ void bbepWriteRow(FASTEPDSTATE *pState, uint8_t *pData, int iLen)
     }
     while (!transfer_is_done) {
         delayMicroseconds(1);
+        vTaskDelay(0);
     }
 } /* bbepWriteRow() */
 
@@ -955,6 +956,9 @@ uint8_t ucTemp[4];
 //
 int bbepIOInit(FASTEPDSTATE *pState)
 {
+    #ifndef ARDUINO
+        esp_log_level_set("gpio", ESP_LOG_NONE);
+    #endif
     int rc = (*(pState->pfnIOInit))(pState);
     if (rc != BBEP_SUCCESS) return rc;
     // Initialize the ESP32 LCD API to drive parallel data at high speed
@@ -1351,6 +1355,7 @@ int bbepFullUpdate(FASTEPDSTATE *pState, bool bFast, bool bKeepOn, BBEPRECT *pRe
                             d[n + 3] = (pGrayUpper[pass * 256 + s[6]] | pGrayLower[pass * 256 + s[7]]);
                             s += 8;
                         } // for j
+                        vTaskDelay(0);
                     }
                     if (iStartCol > 0 || iEndCol < pState->native_width-1) { // There is a region rectangle defined, clip the output to it
                         uint32_t *src, *dst;

--- a/src/arduino_io.inl
+++ b/src/arduino_io.inl
@@ -29,9 +29,9 @@ static uint8_t u8SDA_Pin, u8SCL_Pin;
 static int iDelay = 1;
 #endif
 
+#include "rom/ets_sys.h"
 #ifndef ARDUINO
 #include "driver/gpio.h"
-#include "driver/i2c.h"
 #include "esp_timer.h"
 
 // GPIO modes
@@ -55,25 +55,11 @@ unsigned long millis(void)
 {
     return micros() / 1000;
 }
+
 void IRAM_ATTR delayMicroseconds(uint32_t us)
 {
-    uint32_t m = micros();
-    if (us)
-    {
-        uint32_t e = (m + us);
-        if (m > e)
-        { //overflow
-            while (micros() > e)
-            {
-                __asm__ __volatile__("nop\n");
-            }
-        }
-        while (micros() < e)
-        {
-            __asm__ __volatile__("nop\n");
-        }
-    }
-} /* delayMicroseconds() */
+    ets_delay_us(us);
+}
 
 void delay(uint32_t ms)
 {


### PR DESCRIPTION
Hello Larry,
This updates where done to avoid the WDT warnings and also the constant GPIO state logging that does everything slower in IDF:

```c
 int bbepIOInit(FASTEPDSTATE *pState)
 {
    #ifndef ARDUINO
        esp_log_level_set("gpio", ESP_LOG_NONE);
    #endif
....
}
```
Please place anywhere else if that is not the best place. This will avoid to log in Serial the gpio output states getting toggled by the new I2C Bitbanging. Because this is making everything 20 times slower in IDF when it's activated.


In the other hand the:

     vTaskDelay(0);
     

Are just to avoid the WDT red warnings that come all the time when using big displays. 
