### PR TITLE
Improve anti aliased text rendering

### DIFF
--- a/src/bb_ep_gfx.inl
+++ b/src/bb_ep_gfx.inl
@@ -1147,6 +1147,9 @@ int bbepWriteStringCustom(FASTEPDSTATE *pBBEP, const void *pFont, int x, int y, 
                 for (ty=dy; ty<end_y+1 && ty+1 < height; ty++) {
                     uint8_t u8, u8Count, u8Color;
                     g5_decode_line(&g5dec, &u8Cache[(ty & 1) * iLineSize]);
+                    if (w & 7) {
+                        u8Cache[(ty & 1) * iLineSize + iLineSize - 1] &= u8EndMask;
+                    }
                     if (ty & 1 && ty/2 >= 0) {
                         Scale2Gray(u8Cache, iLineSize, iLineSize); // convert a pair of lines
                         s = u8Cache;

--- a/src/bb_ep_gfx.inl
+++ b/src/bb_ep_gfx.inl
@@ -1156,7 +1156,7 @@ int bbepWriteStringCustom(FASTEPDSTATE *pBBEP, const void *pFont, int x, int y, 
                         u8 = *s++; // grab first byte
                         u8Count = 4;
                         for (tx=x+x_off; tx<x+x_off+tw && tx < width; tx+=2) {
-                            u8Color = grayColors[u8>>6];
+                            u8Color = grayColors[iBG == BBEP_BLACK ? 3 - (u8>>6) : u8>>6]; // invert the color if we're on a black background
                             (*pBBEP->pfnSetPixelFast)(pBBEP, tx/2, ty/2, u8Color);
                             u8 <<= 2;
                             u8Count--;

--- a/src/bb_ep_gfx.inl
+++ b/src/bb_ep_gfx.inl
@@ -1146,7 +1146,9 @@ int bbepWriteStringCustom(FASTEPDSTATE *pBBEP, const void *pFont, int x, int y, 
                 memset(u8Cache, 0, iLineSize*2); // start with 2 lines of white (gray table is inverted)
                 for (ty=dy; ty<end_y+1 && ty+1 < height; ty++) {
                     uint8_t u8, u8Count, u8Color;
-                    g5_decode_line(&g5dec, &u8Cache[(ty & 1) * iLineSize]);
+                    uint8_t *lineBuf = &u8Cache[(ty & 1) * iLineSize];
+                    memset(lineBuf, 0, iLineSize);
+                    g5_decode_line(&g5dec, lineBuf);
                     if (w & 7) {
                         u8Cache[(ty & 1) * iLineSize + iLineSize - 1] &= u8EndMask;
                     }

--- a/src/bb_ep_gfx.inl
+++ b/src/bb_ep_gfx.inl
@@ -1159,7 +1159,11 @@ int bbepWriteStringCustom(FASTEPDSTATE *pBBEP, const void *pFont, int x, int y, 
                         u8Count = 4;
                         for (tx=x+x_off; tx<x+x_off+tw && tx < width; tx+=2) {
                             u8Color = grayColors[iBG == BBEP_BLACK ? 3 - (u8>>6) : u8>>6]; // invert the color if we're on a black background
-                            (*pBBEP->pfnSetPixelFast)(pBBEP, tx/2, ty/2, u8Color);
+                            if (u8Color != iBG) {
+                                // draw the pixel if it's not transparent
+                                // avoid overlapping the previous character's pixels if the font is Italic for example
+                                (*pBBEP->pfnSetPixelFast)(pBBEP, tx/2, ty/2, u8Color);
+                            }
                             u8 <<= 2;
                             u8Count--;
                             if (u8Count == 0) {

--- a/src/bb_ep_gfx.inl
+++ b/src/bb_ep_gfx.inl
@@ -1141,7 +1141,9 @@ int bbepWriteStringCustom(FASTEPDSTATE *pBBEP, const void *pFont, int x, int y, 
             }
             tw = w;
             if (pBBEP->anti_alias) { // draw half-size anti-aliased characters
-                const uint8_t grayColors[4] = {0xf, 0xc, 0x6, 0};
+                const uint8_t grayColorPalette[4] = {0xf, 0xc, 0x6, 0};
+                const uint8_t invertedGrayColorPalette[4] = {0, 0x6, 0xc, 0xf};
+                const uint8_t *grayColors = iBG == BBEP_BLACK ? invertedGrayColorPalette : grayColorPalette; // invert the gray table if we're on a black background
                 int iLineSize = (tw+7)/8;
                 memset(u8Cache, 0, iLineSize*2); // start with 2 lines of white (gray table is inverted)
                 for (ty=dy; ty<end_y+1 && ty+1 < height; ty++) {
@@ -1156,7 +1158,7 @@ int bbepWriteStringCustom(FASTEPDSTATE *pBBEP, const void *pFont, int x, int y, 
                         u8 = *s++; // grab first byte
                         u8Count = 4;
                         for (tx=x+x_off; tx<x+x_off+tw && tx < width; tx+=2) {
-                            u8Color = grayColors[iBG == BBEP_BLACK ? 3 - (u8>>6) : u8>>6]; // invert the color if we're on a black background
+                            u8Color = grayColors[u8>>6];
                             if (u8Color != iBG) {
                                 // draw the pixel if it's not transparent
                                 // avoid overlapping the previous character's pixels if the font is Italic for example

--- a/src/bb_ep_gfx.inl
+++ b/src/bb_ep_gfx.inl
@@ -1146,9 +1146,7 @@ int bbepWriteStringCustom(FASTEPDSTATE *pBBEP, const void *pFont, int x, int y, 
                 memset(u8Cache, 0, iLineSize*2); // start with 2 lines of white (gray table is inverted)
                 for (ty=dy; ty<end_y+1 && ty+1 < height; ty++) {
                     uint8_t u8, u8Count, u8Color;
-                    uint8_t *lineBuf = &u8Cache[(ty & 1) * iLineSize];
-                    memset(lineBuf, 0, iLineSize);
-                    g5_decode_line(&g5dec, lineBuf);
+                    g5_decode_line(&g5dec, &u8Cache[(ty & 1) * iLineSize]);
                     if (w & 7) {
                         u8Cache[(ty & 1) * iLineSize + iLineSize - 1] &= u8EndMask;
                     }


### PR DESCRIPTION
Hi @bitbank2 - this library is amazing and I am loving your work

I am using your library to control a LILYGO T5 E-Paper S3 Pro and I'm displaying some anti aliased text

I've encountered some small visual bugs and I'm also hoping to add dark mode support

Hopefully this PR helps to explain what the problem is and possible fixes

* Inverted the grayscale color mapping when the background is black (`bbepWriteStringCustom`, `src/bb_ep_gfx.inl`).
* Added a check to only draw pixels that are not the background color, which prevents drawing transparent pixels and avoids overlapping pixels from previous characters (important for italic fonts) (`bbepWriteStringCustom`, `src/bb_ep_gfx.inl`).
* Cleared the line buffer before decoding each line to prevent artifacts from previous data (`bbepWriteStringCustom`, `src/bb_ep_gfx.inl`).
* Applied a mask to the last byte of the line buffer when the width is not a multiple of 8, improving edge rendering accuracy (`bbepWriteStringCustom`, `src/bb_ep_gfx.inl`).

Before - note the vertical edges and the clipped italic text
<img width="963" height="1279" alt="image" src="https://github.com/user-attachments/assets/491fe7c1-5728-4af1-a3de-de7d2f84d02f" />

Before - white text on black background
<img width="963" height="1279" alt="image" src="https://github.com/user-attachments/assets/413eee27-c43d-476a-9a9c-589b85f3dca4" />


After - fixed vertical edges and clipped text
<img width="963" height="1279" alt="image" src="https://github.com/user-attachments/assets/a09c108d-04af-49ba-a2db-d7be5a373152" />

After - inverted grays if background is black
<img width="963" height="1279" alt="image" src="https://github.com/user-attachments/assets/70827f46-2f8d-49f9-a14d-5c439e8bf44e" />