### PR TITLE
fix: M5 Paper panel initialization

### DIFF
--- a/src/FastEPD.inl
+++ b/src/FastEPD.inl
@@ -2547,6 +2547,8 @@ int bbepInitPanel(FASTEPDSTATE *pState, int iPanel, uint32_t u32Speed)
             if (rc == BBEP_SUCCESS) {
                 rc = bbepSetPanelSize(pState, pState->width, pState->height, pState->iFlags, pState->iVCOM);
             }
+            // IT8951 uses its dedicated initialization and does not have generic panel I/O callbacks.
+            return rc;
         }
         // Get the 5 callback functions
         pState->pfnEinkPower = panelProcs[iPanel].pfnEinkPower;


### PR DESCRIPTION
When testing, I noticed it needed an early return to not hit null callbacks and crash during initialization.

Once fixed, could init fully and use: 

<img width="720" height="960" alt="image" src="https://github.com/user-attachments/assets/a732e21d-04b3-4070-b2f8-9ab318a46e9b" />
